### PR TITLE
automatically build zip file on release

### DIFF
--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -1,0 +1,21 @@
+name: Main
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: aws/logs_monitoring/tools/package-zip.sh ${{ github.ref }}
+      - name: Upload Asset
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Release.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -846,6 +846,16 @@ def parse_event_type(event):
     raise Exception("Event type not supported (see #Event supported section)")
 
 
+def get_s3_tags(tag_response):
+    tags = ''
+    try:
+        tagSet = tag_response['TagSet']
+        tags = ','.join([ f'{t["Key"]}:{t["Value"]}' for t in tagSet ])
+    except:
+        pass
+    return tags
+
+
 # Handle S3 events
 def s3_handler(event, context, metadata):
     s3 = boto3.client("s3")
@@ -853,6 +863,15 @@ def s3_handler(event, context, metadata):
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"])
+
+    # Find s3 bucket tags and append them to the custom tags if we can find any
+    try:
+        tag_response = s3.get_bucket_tagging(Bucket=bucket)
+    except Exception:
+        tag_response = []
+    bucket_tags = get_s3_tags(tag_response)
+    if len(bucket_tags) > 0:
+        metadata[DD_CUSTOM_TAGS] += ',' + bucket_tags
 
     source = parse_event_source(event, key)
     metadata[DD_SOURCE] = source

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -847,10 +847,10 @@ def parse_event_type(event):
 
 
 def get_s3_tags(tag_response):
-    tags = ''
+    tags = ""
     try:
-        tagSet = tag_response['TagSet']
-        tags = ','.join([ f'{t["Key"]}:{t["Value"]}' for t in tagSet ])
+        tagSet = tag_response["TagSet"]
+        tags = ",".join([f'{t["Key"]}:{t["Value"]}' for t in tagSet])
     except:
         pass
     return tags
@@ -871,7 +871,7 @@ def s3_handler(event, context, metadata):
         tag_response = []
     bucket_tags = get_s3_tags(tag_response)
     if len(bucket_tags) > 0:
-        metadata[DD_CUSTOM_TAGS] += ',' + bucket_tags
+        metadata[DD_CUSTOM_TAGS] += "," + bucket_tags
 
     source = parse_event_source(event, key)
     metadata[DD_SOURCE] = source

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -15,11 +15,15 @@ cd $DIR
 if [ -z "$1" ]; then
     echo "Must specify a desired version number"
     exit 1
-elif [[ ! $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Must use a semantic version, e.g., 3.1.4"
-    exit 1
 else
-    VERSION=$1
+    if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        VERSION=$1
+    elif [[ $1 =~ ref/tags/[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        VERSION="$(echo $1 | cut -d/ -f3)"
+    else
+        echo "Must use a semantic version, e.g., 3.1.4"
+        exit 1
+    fi
 fi
 
 PYTHON_VERSION="3.7"


### PR DESCRIPTION
This commit adds a github action to run script that creates the .zip file that is normally released to the release as an asset. Then it appends it to the release that was just created

tested that docker does exist on the executor in a test repo so these docker commands will run